### PR TITLE
Конфигурация логгера проекта

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,11 @@
+"""Модуль настроек и констант проекта"""
+
+# # Глобальные настройки логгера
+BACKUP_COUNT = 5
+ENCODING = "UTF-8"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+FORMAT = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+LOGGING_LEVEL = "DEBUG"
+LOGS_FOLDER = "logs"
+LOGS_FILE = "logfile.log"
+MAX_BYTES = 50_000_000

--- a/logger_config.py
+++ b/logger_config.py
@@ -1,0 +1,36 @@
+"""Модуль инициализации глобальных настроек логгера."""
+
+import logging
+import os
+import sys
+from logging.handlers import RotatingFileHandler
+
+from config import (
+    BACKUP_COUNT,
+    DATE_FORMAT,
+    ENCODING,
+    FORMAT,
+    LOGGING_LEVEL,
+    LOGS_FILE,
+    LOGS_FOLDER,
+    MAX_BYTES,
+)
+
+
+def init_globals_logging():
+    """Инициализация глобальных настроек логгера."""
+    os.makedirs(LOGS_FOLDER, exist_ok=True)
+    logging.basicConfig(
+        level=getattr(logging, LOGGING_LEVEL, "DEBUG"),
+        format=FORMAT,
+        datefmt=DATE_FORMAT,
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+            RotatingFileHandler(
+                os.path.join(LOGS_FOLDER, LOGS_FILE),
+                encoding=ENCODING,
+                maxBytes=MAX_BYTES,
+                backupCount=BACKUP_COUNT,
+            ),
+        ],
+    )


### PR DESCRIPTION
Конфигурация логгера проекта.

Использование:
в файле main.py перед запуском, функции запуска проекта, запускаем функцию конфигурации логгера.

Пример:
```py
import logging
from logger_config import init_globals_logging

logger = logging.getLogger(__name__)

if __name__ == "__main__":
    init_globals_logging()
    main()
```